### PR TITLE
fix: Sync filename

### DIFF
--- a/components/UtilityPanel.tsx
+++ b/components/UtilityPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { useDispatch } from "react-redux";
 import { handleMapping } from "@/store/canvasSlice";
 
@@ -16,7 +16,7 @@ type Severity = "success" | "info" | "warn" | "error";
 
 const UtilityPanel = () => {
   const dispatch = useDispatch();
-  const [filename, setFilename] = useState<string>("");
+  const filenameRef = useRef<string>("");
   const toast = useRef<Toast>(null);
   const url = process.env.NEXT_PUBLIC_WEB_API_URL;
 
@@ -64,8 +64,7 @@ const UtilityPanel = () => {
     // dialog for save button
     const accept = async () => {
       try {
-        // await axios.get(url + `/mapping/save/33`);
-        await axios.get(url + `/mapping/save/${filename}`);
+        await axios.get(url + `/mapping/save/${filenameRef.current}`);
 
         showToast("info", "Save", "Save succeed");
       } catch (e) {
@@ -84,7 +83,7 @@ const UtilityPanel = () => {
             <InputText
               id="filename"
               onChange={(e) => {
-                setFilename(e.target.value);
+                filenameRef.current = e.target.value;
               }}
             />
             <label htmlFor="filename">Filename</label>


### PR DESCRIPTION
useState로 filename을 관리시 state의 비동기 업데이트로 인한 filename의 싱크가 맞지 않는 문제가 있었음. useRef를 사용하여 최신값을 참조할 수 있도록 변경.

ex) initial filename = ""
filename을 "first"로 change -> save request -> filename이 ""로 전달됨 -> 에러발생
filename을 "second"로 change -> save request -> filename이 "first"로 전달됨 -> 의도하지 않은 이름으로 파일이 저장