### PR TITLE
Fix/transform arrow sync

### DIFF
--- a/components/LidarCanvas.tsx
+++ b/components/LidarCanvas.tsx
@@ -268,31 +268,6 @@ const LidarCanvas = ({
     dispatchChange();
   };
 
-  // Update a ArrowHelper to point to a correct location.
-  const updateLinks = (selectedObj: THREE.Object3D) => {
-    const scene = sceneRef.current;
-    if (!scene || !selectedObj) return;
-
-    let tempLinks = [...selectedObj.userData.links];
-    selectedObj.userData.links = [];
-
-    for (const link of tempLinks) {
-      const to = scene.getObjectByProperty("uuid", link);
-      if (to) {
-        addLinks(selectedObj, to);
-      }
-    }
-    tempLinks = [...selectedObj.userData.links_from];
-    selectedObj.userData.links_from = [];
-
-    for (const link of tempLinks) {
-      const from = scene.getObjectByProperty("uuid", link);
-      if (from) {
-        addLinks(from, selectedObj);
-      }
-    }
-  };
-
   const init3DScene = () => {
     if (!canvasRef.current) return;
     // scene
@@ -1542,6 +1517,31 @@ const LidarCanvas = ({
       to.userData.links_from = links;
 
       dispatchChange();
+    }
+  };
+
+  // Update a ArrowHelper to point to a correct location.
+  const updateLinks = (selectedObj: THREE.Object3D) => {
+    const scene = sceneRef.current;
+    if (!scene || !selectedObj) return;
+
+    let tempLinks = [...selectedObj.userData.links];
+    selectedObj.userData.links = [];
+
+    for (const link of tempLinks) {
+      const to = scene.getObjectByProperty("uuid", link);
+      if (to) {
+        addLinks(selectedObj, to);
+      }
+    }
+    tempLinks = [...selectedObj.userData.links_from];
+    selectedObj.userData.links_from = [];
+
+    for (const link of tempLinks) {
+      const from = scene.getObjectByProperty("uuid", link);
+      if (from) {
+        addLinks(from, selectedObj);
+      }
     }
   };
 

--- a/components/LidarCanvas.tsx
+++ b/components/LidarCanvas.tsx
@@ -33,6 +33,7 @@ interface UserData {
   id: string;
   info: string;
   links: string[];
+  links_from?: string[];
   name: string;
   pose: string;
   type: string;
@@ -199,9 +200,10 @@ const LidarCanvas = ({
   }, [isMarkingMode]);
 
   const updateProperty = (category: string, value: string) => {
+    const scene = sceneRef.current;
     const selectedObj = selectedNodeRef.current;
     const currSelectionBox = currSelectionBoxRef.current;
-    if (!selectedObj || !currSelectionBox) return;
+    if (!scene || !selectedObj || !currSelectionBox) return;
 
     switch (category) {
       case "name":
@@ -224,13 +226,18 @@ const LidarCanvas = ({
         break;
       case "pose-x":
         selectedObj.position.x = Number(value);
+        removeAllLinksRelateTo(selectedObj.uuid);
+        updateLinks(selectedObj);
         break;
       case "pose-y":
         selectedObj.position.y = Number(value);
+        removeAllLinksRelateTo(selectedObj.uuid);
+        updateLinks(selectedObj);
         break;
-      case "pose-z":
-        selectedObj.position.z = Number(value);
-        break;
+      // case "pose-z":
+      //   selectedObj.position.z = Number(value);
+      //   updateLinks(selectedObj)
+      //   break;
       case "pose-rz":
         selectedObj.rotation.z = Number(value);
         break;
@@ -259,6 +266,31 @@ const LidarCanvas = ({
 
     // update selected object info
     dispatchChange();
+  };
+
+  // Update a ArrowHelper to point to a correct location.
+  const updateLinks = (selectedObj: THREE.Object3D) => {
+    const scene = sceneRef.current;
+    if (!scene || !selectedObj) return;
+
+    let tempLinks = [...selectedObj.userData.links];
+    selectedObj.userData.links = [];
+
+    for (const link of tempLinks) {
+      const to = scene.getObjectByProperty("uuid", link);
+      if (to) {
+        addLinks(selectedObj, to);
+      }
+    }
+    tempLinks = [...selectedObj.userData.links_from];
+    selectedObj.userData.links_from = [];
+
+    for (const link of tempLinks) {
+      const from = scene.getObjectByProperty("uuid", link);
+      if (from) {
+        addLinks(from, selectedObj);
+      }
+    }
   };
 
   const init3DScene = () => {
@@ -489,6 +521,7 @@ const LidarCanvas = ({
 
       selectedNodeRef.current = topParent;
       transformControl.attach(topParent);
+      // console.log("selected Object: ", topParent);
 
       // nodes push
       // if (!selectedNodesArray.includes(topParent)) {
@@ -1174,6 +1207,7 @@ const LidarCanvas = ({
         node.name = `${prefix}-${formatNumber(i + 1)}`;
         node.userData.index = i;
         node.userData.links = [];
+        node.userData.links_from = [];
         node.userData.type = type;
         node.userData.info = "";
         break;
@@ -1354,6 +1388,11 @@ const LidarCanvas = ({
     if (currSelectionBox && transformControl && transformControl.object) {
       currSelectionBox.setFromObject(transformControl.object);
     }
+    if (selectedNodeRef.current) {
+      removeAllLinksRelateTo(selectedNodeRef.current.uuid);
+      updateLinks(selectedNodeRef.current);
+    }
+
     dispatchChange();
     render();
   };
@@ -1381,8 +1420,15 @@ const LidarCanvas = ({
     let links: string[] = [];
     links = [...from.userData.links];
     if (!links.includes(to.uuid)) {
+      // Add uuid of the pointing node
       links.push(to.uuid);
       from.userData.links = links;
+    }
+    links = [...to.userData.links_from];
+    if (!links.includes(from.uuid)) {
+      // Add uuid of the node that points to itself
+      links.push(from.uuid);
+      to.userData.links_from = links;
     }
   };
 
@@ -1443,9 +1489,12 @@ const LidarCanvas = ({
     const nodes = nodesRef.current;
     if (!scene) return;
 
-    // Update all nodes userdata(expecially, links)
+    // Update all nodes userdata(expecially, links) except itself.
     nodes.forEach((node) => {
-      node.userData.links = (node.userData.links as string[]).filter(
+      node.userData.links = (node.userData as UserData).links.filter(
+        (uuid: string) => uuid !== targetNodeUUID
+      );
+      node.userData.links_from = (node.userData.links_from as string[]).filter(
         (uuid: string) => uuid !== targetNodeUUID
       );
     });
@@ -1453,8 +1502,9 @@ const LidarCanvas = ({
     // Because an arrow's name convention is `arrow-startNodeName-endNodeName`
     const target = scene.getObjectByProperty("uuid", targetNodeUUID);
     if (target) {
-      const targetArrows = scene.children.filter((child) =>
-        child.name.includes(target.name)
+      const targetArrows = scene.children.filter(
+        (child) =>
+          child.name.includes(target.name) && child.type === "ArrowHelper"
       );
 
       targetArrows.forEach((arrow) => {
@@ -1463,11 +1513,11 @@ const LidarCanvas = ({
     }
   };
 
-  const removeLink = (nodeId: string, deleteNodeName: string) => {
+  const removeLink = (fromUUID: string, toNodeName: string) => {
     const scene = sceneRef.current;
     if (!scene) return;
-    const from = scene.getObjectByProperty("uuid", nodeId);
-    const to = scene.getObjectByName(deleteNodeName);
+    const from = scene.getObjectByProperty("uuid", fromUUID);
+    const to = scene.getObjectByName(toNodeName);
 
     if (!from || !to) return;
     const targetArrow = scene.getObjectByName(`arrow-${from.name}-${to.name}`);
@@ -1477,11 +1527,19 @@ const LidarCanvas = ({
       // Update selected node's userData.links
       let links: string[] = [];
       links = [...from.userData.links];
-      const index = links.findIndex((link) => {
+      let index = links.findIndex((link) => {
         link === to.uuid;
       });
       links.splice(index, 1);
       from.userData.links = links;
+
+      // Update from data
+      links = [...to.userData.links_from];
+      index = links.findIndex((link) => {
+        link === from.uuid;
+      });
+      links.splice(index, 1);
+      to.userData.links_from = links;
 
       dispatchChange();
     }

--- a/pages/api/socket.ts
+++ b/pages/api/socket.ts
@@ -1,46 +1,35 @@
 import { Server } from "socket.io";
 import io from "socket.io-client";
 import type { NextApiRequest, NextApiResponse } from "next";
-// import { getMobileSocketURL } from "@/app/(main)/api/url";
 
 async function ioHandler(req: NextApiRequest, res: NextApiResponse) {
   if (!(res.socket as any).server.io) {
-    console.log("*First use, starting socket.io");
+    // First use, starting socket.io
 
-    const io2 = new Server((res.socket as any).server);
-    // let url = await getMobileSocketURL();
+    const ioServer = new Server((res.socket as any).server);
     const url = "http://10.108.1.40:10334/";
-    let socket = io(url);
-
-    let connectedClients = [];
+    const socket = io(url);
 
     socket.on("connect", () => {
-      console.log("??????????????????????????????");
       socket.on("mapping", (data: string[][]) => {
-        console.log("mapping in");
-        io2.emit("mapping", data);
+        ioServer.emit("mapping", data);
       });
       socket.on("lidar", (data: string[][]) => {
-        io2.emit("lidar", data);
+        ioServer.emit("lidar", data);
       });
       socket.on("status", (data: JSON) => {
-        // console.log("status get ",data.condition.auto_state);
-        io2.emit("status", data);
+        ioServer.emit("status", data);
       });
     });
 
-    io2.on("connection", (newsocket) => {
-      console.log(`${socket.id} connected`);
-      console.log("count : ", io2.engine.clientsCount);
-
-      io2.on("disconnect", (socket) => {
-        console.log(`${socket.id} disconnected`);
-        // io.leave();
+    ioServer.on("connection", (newsocket) => {
+      newsocket.on("disconnect", () => {
+        console.log(`${newsocket.id} disconnected`);
       });
     });
-    (res.socket as any).server.io = io2;
+    (res.socket as any).server.io = ioServer;
   } else {
-    console.log("socket.io already running");
+    console.warn("socket.io already running");
   }
   res.end();
 }


### PR DESCRIPTION
- 선택된 오브젝트(노드)의 트랜스폼이 일어났을 때 Arrow Helper에 트랜스폼이 반영되지 않던 문제 해결
- 노드 A를 기준으로 'A가 가리키는 에로우 헬퍼', 'A를 가리키는 에로우 헬퍼'를 업데이트
- A를 가리키는 노드들을 노드의 유저데이터에 'links_from' 배열로 관리(A의 uuid로 자신을 가리키는 노드를 전체 씬을 순회하여 얻어내려 했으나, 이 접근법의 경우 노드가 많아지면 순회하는데 많은 시간이 소요될 수 있어 지금의 방식을 채택)