### PR TITLE
fix: Resolving issues that were not saved when returning to the map p…

### DIFF
--- a/app/(main)/map/page.tsx
+++ b/app/(main)/map/page.tsx
@@ -99,6 +99,7 @@ const Map: React.FC = () => {
 
   useEffect(() => {
     syncCanvasWithSlamNav();
+    fileNameRef.current = map;
   }, [map]);
 
   useEffect(() => {

--- a/components/LidarCanvas.tsx
+++ b/components/LidarCanvas.tsx
@@ -63,8 +63,15 @@ const LidarCanvas = ({
 }: LidarCanvasProps) => {
   const dispatch = useDispatch();
   // root state
-  const { action, isMarkingMode, robotHelper } = useSelector(
-    (state: RootState) => state.canvas
+  // const { action, isMarkingMode, robotHelper } = useSelector(
+  //   (state: RootState) => state.canvas
+  // );
+  const action = useSelector((state: RootState) => state.canvas.action);
+  const isMarkingMode = useSelector(
+    (state: RootState) => state.canvas.isMarkingMode
+  );
+  const robotHelper = useSelector(
+    (state: RootState) => state.canvas.robotHelper
   );
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -242,6 +249,7 @@ const LidarCanvas = ({
         case CANVAS_ACTION.DRAW_CLOUD_TOPO:
           clearMapPoints(CANVAS_CLASSES.DEFAULT);
           drawCloud(CANVAS_CLASSES.DEFAULT, cloudData);
+          clearAllNodes();
           drawTopo();
           break;
         case CANVAS_ACTION.SAVE_MAP:
@@ -267,6 +275,13 @@ const LidarCanvas = ({
       }
     }
   }, [action]);
+
+  useEffect(() => {
+    goalNum.current = 0;
+    routeNum.current = 0;
+    dispatch(updateGoalNum(goalNum.current));
+    dispatch(updateRouteNum(routeNum.current));
+  }, [cloudData, topoData]);
 
   const setPropertyUndoRedo = (category: string, value: string): void => {
     const selectedObj = selectedNodeRef.current;
@@ -1221,9 +1236,8 @@ const LidarCanvas = ({
 
   const drawTopo = async () => {
     const scene = sceneRef.current;
-    if (!topoData || !scene) return;
+    if (!topoData || !scene || !topoData.length) return;
 
-    clearAllNodes();
     // repaint all nodes
 
     const tasks = topoData.map((topo, i) => {
@@ -1701,6 +1715,7 @@ const LidarCanvas = ({
   };
 
   const saveMap = async (filename: string) => {
+    if (cloudRef.current === null) return;
     const annoRes = await saveAnnotation(filename);
     const cloudRes = await saveCloud(filename);
 

--- a/store/reducers.ts
+++ b/store/reducers.ts
@@ -1,4 +1,3 @@
-// reducers/index.js
 import { combineReducers } from "redux";
 import { persistReducer } from "redux-persist";
 import storage from "redux-persist/lib/storage";
@@ -12,25 +11,25 @@ import taskSlice from "./taskSlice";
 import canvasReducer from "./canvasSlice";
 import propertyPanelReducer from "./propertyPanelSlices";
 
-export const rootReducer = combineReducers({
-    network: networkReducer,
-    setting: settingReducer,
-    status: statusReducer,
-    connection: connectionSlice,
-    canvas: canvasReducer,
-    propertyPanel: propertyPanelReducer,
-    user: userReducer,
-    task: taskSlice
+const rootReducer = combineReducers({
+  network: networkReducer,
+  setting: settingReducer,
+  status: statusReducer,
+  connection: connectionSlice,
+  canvas: canvasReducer,
+  propertyPanel: propertyPanelReducer,
+  user: userReducer,
+  task: taskSlice,
 });
 
 const persistConfig = {
-    key: "root",
-    // localStorage에 저장합니다.
-    storage,
-    // auth, board, studio 3개의 reducer 중에 auth reducer만 localstorage에 저장합니다.
-    whitelist: ["user", "network"]
-    // blacklist -> 그것만 제외합니다
-  };
+  key: "root",
+  // localStorage에 저장합니다.
+  storage,
+  // auth, board, studio 3개의 reducer 중에 auth reducer만 localstorage에 저장합니다.
+  whitelist: ["user", "network"],
+  // blacklist -> 그것만 제외합니다
+};
 
-  
-export default persistReducer(persistConfig, rootReducer);
+export default persistReducer(persistConfig, rootReducer) as typeof rootReducer;
+

--- a/store/store.tsx
+++ b/store/store.tsx
@@ -1,43 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
-import { useMemo } from "react";
-import { createWrapper } from "next-redux-wrapper";
-import networkReducer from "./networkSlice";
-import userReducer from "./userSlice";
-import settingReducer from "./settingSlice";
-import statusReducer from "./statusSlice";
-import connectionSlice from "./connectionSlice";
-import taskSlice from "./taskSlice";
-import canvasReducer from "./canvasSlice";
-import propertyPanelReducer from "./propertyPanelSlices";
-import { rootReducer } from "./reducers";
-import { PersistGate } from "redux-persist/integration/react";
-import thunk from 'redux-thunk';
-
-import {
-  FLUSH,
-  REHYDRATE,
-  PAUSE,
-  PERSIST,
-  PURGE,
-  REGISTER,
-} from 'redux-persist';
-import { persistStore, persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage'; // localStorage를 사용할 경우
-const persistConfig = {
-  key: 'root',
-  // version: 1,
-  storage: storage
-};
-const persistedReducer = persistReducer(persistConfig, rootReducer);
+import rootReducer from "./reducers";
+import { persistStore } from "redux-persist";
 
 export const store = configureStore({
-  reducer:persistedReducer,
+  reducer: rootReducer,
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
-        serializableCheck: false
-        // {
-        //     ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER]
-        // },
+      serializableCheck: false,
     }),
 });
 export const persistor = persistStore(store);


### PR DESCRIPTION
…age after the route change.

# First commit: 
라우팅 변경시 map route가 SLAM과 sync 되고 있긴 했지만, map 저장이 안되던 문제 해결

# Second commit:
redux state들이 useSelector로 접근시 반환 값으로 state | undefined이던 문제를 해결

```
// as typeof rootReducer가 추가 됨 
export default persistReducer(persistConfig, rootReducer) as typeof rootReducer; 
```

### persistReducer의 반환 타입:
persistReducer는 리듀서를 감싸서 퍼시스트 기능을 추가합니다. 이 과정에서 원래의 리듀서와 타입이 달라지기 때문에, TypeScript는 이 변경된 리듀서의 타입을 인식하고 undefined일 수 있다고 경고를 보냅니다. 그래서 state.canvas가 undefined가 될 수 있다고 에러가 발생한 것입니다.
### as typeof rootReducer의 효과:
persistReducer가 반환한 리듀서가 실제로는 rootReducer와 동일한 상태 트리를 관리하지만, TypeScript는 이를 정확히 알지 못합니다. as typeof rootReducer를 사용해서 TypeScript에게 “이 리듀서는 rootReducer와 동일한 구조를 가질 것”이라고 알려주면, 타입 검사 에러가 사라집니다.

결론:

as typeof rootReducer를 사용함으로써 TypeScript는 persistReducer가 반환하는 리듀서가 정확히 rootReducer와 같은 구조라고 이해하게 되어, state.canvas가 undefined가 아닐 것이라는 것을 인식하게 되어 에러가 사라진 것입니다.


