### PR TITLE
fix: Set the z-index for the correct rendering order

### DIFF
--- a/components/LidarCanvas.tsx
+++ b/components/LidarCanvas.tsx
@@ -499,6 +499,7 @@ const LidarCanvas = ({
 
     // control
     const control = new MapControls(camera, renderer.domElement);
+    control.addEventListener("change", updateLabelScale);
     controlRef.current = control;
 
     control.screenSpacePanning = true;
@@ -984,6 +985,9 @@ const LidarCanvas = ({
           redoCommand();
         }
         break;
+      // NOTE: This key input has been specified for testing purposes.
+      // case "KeyP":
+      // break;
       default:
         break;
     }
@@ -1593,12 +1597,30 @@ const LidarCanvas = ({
     nodeDiv.style.backgroundColor = "transparent";
 
     nodeDiv.style.position = "absolute";
+    nodeDiv.style.fontSize = "30px";
     nodeDiv.style.zIndex = "-999";
 
     const nodeLabel = new CSS2DObject(nodeDiv);
     nodeLabel.name = "label";
-    nodeLabel.center.set(-0.2, 1.5);
+    nodeLabel.center.set(-0.2, 0.5);
     node.add(nodeLabel);
+  };
+
+  const updateLabelScale = () => {
+    if (!sceneRef.current || !cameraRef.current) return;
+    const labels = sceneRef.current.getObjectsByProperty(
+      "name",
+      "label"
+    ) as CSS2DObject[];
+    for (let i = 0; i < labels.length; i++) {
+      const nodeLabel = labels[i];
+      const distance = cameraRef.current.position.distanceTo(
+        nodeLabel.position
+      );
+
+      nodeLabel.element.style.fontSize = `${(100 / distance) * 150}px`;
+      nodeLabel.center.set(-100 / distance, 250 / distance);
+    }
   };
 
   const removeLabelFromNode = (node: THREE.Object3D) => {

--- a/components/LidarCanvas.tsx
+++ b/components/LidarCanvas.tsx
@@ -1592,6 +1592,9 @@ const LidarCanvas = ({
     nodeDiv.style.color = "white";
     nodeDiv.style.backgroundColor = "transparent";
 
+    nodeDiv.style.position = "absolute";
+    nodeDiv.style.zIndex = "-999";
+
     const nodeLabel = new CSS2DObject(nodeDiv);
     nodeLabel.name = "label";
     nodeLabel.center.set(-0.2, 1.5);

--- a/styles/components/_map.scss
+++ b/styles/components/_map.scss
@@ -25,7 +25,7 @@
 
 #transform-toolbar {
   position: absolute;
-  z-index: 999;
+  z-index: 998;
   top: 72px;
   left: 24px;
   display: flex;

--- a/styles/components/_map.scss
+++ b/styles/components/_map.scss
@@ -7,6 +7,8 @@
 
 .p-menubar,
 .p-menu {
+  position: relative;
+  z-index: 999;
   border-radius: 0px;
   border-bottom-right-radius: 2px;
 }
@@ -23,6 +25,7 @@
 
 #transform-toolbar {
   position: absolute;
+  z-index: 999;
   top: 72px;
   left: 24px;
   display: flex;
@@ -52,6 +55,7 @@
 }
 #property-container {
   position: relative;
+  z-index: 999;
 
   h5 {
     padding-left: 0.5rem;


### PR DESCRIPTION
# Task List
1. z-index setting (Node의 이름이 다른 컴포넌트 패널을 침범하는 현상 제거)

## TO DO LIST
- [x] zoom level에 따른 Node Label 사이즈 조정